### PR TITLE
Adds proxmox_backup

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -196,7 +196,7 @@
   branch = "master"
   name = "github.com/thirdwavellc/go-proxmox"
   packages = ["proxmox"]
-  revision = "d4340a2b56ffaba9fe5950d7f2e292cf387fb315"
+  revision = "06d70c3b8008bcf71f8c49e86a0cafd3b93819af"
 
 [[projects]]
   name = "github.com/ulikunitz/xz"
@@ -243,6 +243,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "6ecfabde5d9ec70795390120b9dc938d694e4c76d0311f27bfa4d341b81d814d"
+  inputs-digest = "eb98b4a595cd974a8e49f752aa15c16e4096c96df05eeb3eb420b94d26bb87b5"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -28,3 +28,7 @@
 [[constraint]]
   branch = "master"
   name = "github.com/thirdwavellc/go-proxmox"
+
+[[constraint]]
+  name = "github.com/satori/go.uuid"
+  version = "1.1.0"

--- a/provider.go
+++ b/provider.go
@@ -30,6 +30,7 @@ func Provider() *schema.Provider {
 		ResourcesMap: map[string]*schema.Resource{
 			"proxmox_container": resourceContainer(),
 			"proxmox_group":     resourceGroup(),
+			"proxmox_backup":    resourceBackup(),
 		},
 		ConfigureFunc: providerConfigure,
 	}

--- a/resource_backup.go
+++ b/resource_backup.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/satori/go.uuid"
+	"github.com/thirdwavellc/go-proxmox/proxmox"
+)
+
+func resourceBackup() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceBackupCreate,
+		Read:   resourceBackupRead,
+		Update: resourceBackupUpdate,
+		Delete: resourceBackupDelete,
+		Schema: map[string]*schema.Schema{
+			"start_time": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"all": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"compress": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"mail_notification": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"mail_to": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"mode": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"node": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func resourceBackupCreate(d *schema.ResourceData, m interface{}) error {
+	client := m.(*proxmox.ProxmoxClient)
+
+	createReq := &proxmox.NewBackupRequest{
+		StartTime:        d.Get("start_time").(string),
+		All:              d.Get("all").(int),
+		Compress:         d.Get("compress").(string),
+		MailNotification: d.Get("mail_notification").(string),
+		MailTo:           d.Get("mail_to").(string),
+		Mode:             d.Get("mode").(string),
+		Node:             d.Get("node").(string),
+	}
+	_, err := client.CreateBackup(createReq)
+
+	if err != nil {
+		return err
+	}
+
+	d.SetId(uuid.NewV4().String())
+
+	return nil
+}
+
+func resourceBackupRead(d *schema.ResourceData, m interface{}) error {
+	// Due to API limitations, we can't perform any actions after creation
+	// This is because the API doesn't return the backup id.
+	// TODO: work around?
+	return nil
+}
+
+func resourceBackupUpdate(d *schema.ResourceData, m interface{}) error {
+	// Due to API limitations, we can't perform any actions after creation
+	// This is because the API doesn't return the backup id.
+	// TODO: work around?
+	return nil
+}
+
+func resourceBackupDelete(d *schema.ResourceData, m interface{}) error {
+	// Due to API limitations, we can't perform any actions after creation
+	// This is because the API doesn't return the backup id.
+	// TODO: work around?
+	return nil
+}


### PR DESCRIPTION
Due to API limitations, only create is currently implemented. Basically,
for resources with auto-generated ids (backups being one of them), it's
impossible to figure out the id of the resource you just created. This
is because all non-GET methods seem to return null.

I have posted this question on the forums, along with a few others:

https://forum.proxmox.com/threads/api-questions.37581/